### PR TITLE
Allow multiple token middleware

### DIFF
--- a/lib/middleware/token.js
+++ b/lib/middleware/token.js
@@ -49,7 +49,7 @@ function token(options) {
   assert(TokenModel, 'loopback.token() middleware requires a AccessToken model');
   
   return function (req, res, next) {
-    if (req.accessToken !== undefined) return next();
+    if (req.accessToken !== undefined && req.accessToken !== null) return next();
     TokenModel.findForRequest(req, options, function(err, token) {
       req.accessToken = token || null;
       next(err);

--- a/lib/middleware/token.js
+++ b/lib/middleware/token.js
@@ -49,7 +49,7 @@ function token(options) {
   assert(TokenModel, 'loopback.token() middleware requires a AccessToken model');
   
   return function (req, res, next) {
-    if (req.accessToken !== undefined && req.accessToken !== null) return next();
+    if (req.accessToken) return next();
     TokenModel.findForRequest(req, options, function(err, token) {
       req.accessToken = token || null;
       next(err);


### PR DESCRIPTION
Changed req.accessToken check to allow multiple token middleware to run.